### PR TITLE
Bug/clears board on mana gain

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Find instructions if you wish to setup your own game server.
 - [ ] support battlebox (shared deck)
 
 ## Bugs
+- [x] updating mana or rolling dice causes board state to clear
 - [ ] graveyard sorting. Ensure that in the handle drag it ignores ordering conditions
 - [ ] firefox maybe shows context menu on right click
 - [x] right click modal, taps card
@@ -27,6 +28,11 @@ Find instructions if you wish to setup your own game server.
 
 
 ## Feedback
+- [ ] 
+
+
+
+## Recently finished
 - [x] roll dice (d6/d20)
 - [x] spawn card/token modal
     - cache the sorcery api data on cards.army
@@ -39,10 +45,6 @@ Find instructions if you wish to setup your own game server.
 - [x] add numbers to grid: numbers 1-20
 - [x] add counters on cards
 - [x] add remaining / total mana
-
-
-
-## Recently finished
 - [x] add websocket for multiplayer
 - [x] landing page
 - [x] setup pages for solo play (1p, 2p rotate self)

--- a/src/components/organisms/Online/CreateLobby.tsx
+++ b/src/components/organisms/Online/CreateLobby.tsx
@@ -117,7 +117,7 @@ export const CreateLobby = () => {
               onClick={onSubmit}
               style={{ width: "100%" }}
             >
-              Create lobby
+              Create/Join lobby
             </button>
             {fields.gid && (
               <HStack

--- a/src/pages/online.tsx
+++ b/src/pages/online.tsx
@@ -53,13 +53,6 @@ const Body = () => {
     });
   }
 
-  function setData(data: PlayerData) {
-    setPlayerState()({
-      state: myState?.state ?? initGameState,
-      data,
-    });
-  }
-
   const socketPlayers =
     gameState?.content?.players ?? ({} as Record<string, PlayerState>);
 
@@ -87,6 +80,14 @@ const Body = () => {
     const localState = myState?.state ?? initGameState;
     return [...combineGameStates(), ...localState.slice(GRIDS.HAND)];
   }, [socketPlayers]);
+
+  function setData(data: PlayerData) {
+    setPlayerState()({
+      state: state ?? initGameState,
+      data,
+      timestamp: Date.now(),
+    });
+  }
 
   if (myState?.state === undefined && name) {
     return (


### PR DESCRIPTION
Previously there was no timestamp on data (prevented a previous bug). But this caused the boardstate to clear if you updated data

now will update timestamp on data but will use the combined state for your view